### PR TITLE
Upgrade to .NET 9 and update GitHub Actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,14 +25,14 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 9.0.x
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v1.1.1
+      uses: gittools/actions/gitversion/setup@v0
       with:
           versionSpec: '5.x'
     - name: Use GitVersion
       id: gitversion # step id used as reference for output values
-      uses: gittools/actions/gitversion/execute@v1.1.1
+      uses: gittools/actions/gitversion/execute@v0
     - run: |
         echo "SemVer: ${{ steps.gitversion.outputs.semVer }}"
     - run: npm install

--- a/src/MimeDb.Generator/MimeDb.Generator.csproj
+++ b/src/MimeDb.Generator/MimeDb.Generator.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/MimeDb.Facts/MimeDb.Facts.csproj
+++ b/tests/MimeDb.Facts/MimeDb.Facts.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This commit includes the following changes:

1.  **Project File Updates (.csproj):**
    *   Updated TargetFramework to `net9.0` for:
        *   `src/MimeDb.Generator/MimeDb.Generator.csproj`
        *   `tests/MimeDb.Facts/MimeDb.Facts.csproj`
    *   `src/MimeDb/MimeDb.csproj` remains `netstandard2.0` for broader compatibility.

2.  **GitHub Actions Workflow (.github/workflows/master.yml):**
    *   Updated .NET SDK version to `9.0.x` using `actions/setup-dotnet@v4`.
    *   Updated `gittools/actions/gitversion/setup` from `v1.1.1` to `v0`.
    *   Updated `gittools/actions/gitversion/execute` from `v1.1.1` to `v0`.
    *   Other actions (`actions/checkout@v4`, `actions/setup-node@v4`, `actions/upload-artifact@v4`) were confirmed to be using their latest floating major versions.

3.  **NuGet Package Updates:**
    *   In `src/MimeDb.Generator/MimeDb.Generator.csproj`:
        *   `System.Text.Json`: `7.0.2` -> `9.0.0`
    *   In `tests/MimeDb.Facts/MimeDb.Facts.csproj`:
        *   `Microsoft.NET.Test.Sdk`: Kept at `17.9.0`
        *   `xunit`: `2.4.2` -> `2.8.0`
        *   `xunit.runner.visualstudio`: `2.4.5` -> `2.8.0`
        *   `coverlet.collector`: `3.2.0` -> `6.0.2`

This work addresses the issue of upgrading to .NET 9 and updating GitHub Actions. Further testing is required to ensure all changes are working correctly.